### PR TITLE
Fix exclude paths in update.sh script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -278,7 +278,7 @@ while IFS= read -r line; do
     fi
     [[ -n "$cpath" ]] || continue
     rel="${cpath#/}"
-    excludes+=( --exclude="${rel}" --exclude="${rel%/}/" )
+    excludes+=( --exclude="/${rel}" --exclude="/${rel%/}/" )
 done < <(grep -E '^mp[0-9]+:' "$LXC_CONF" || true)
 
 # Parse low-level lxc.mount.entry
@@ -288,7 +288,7 @@ while IFS= read -r line; do
     guest_path="${fields[2]}"
     [[ -n "$guest_path" ]] || continue
     rel="${guest_path#/}"
-    excludes+=( --exclude="${rel}" --exclude="${rel%/}/" )
+    excludes+=( --exclude="/${rel}" --exclude="/${rel%/}/" )
 done < <(grep -E '^lxc\.mount\.entry:' "$LXC_CONF" || true)
 
 # Sync files


### PR DESCRIPTION
Without a leading `/`, rsync exclude patterns are unanchored and match at any depth of the tree. The excludes derived from mount points therefore skip more than intended: `--exclude=config` (meant for the `/config` bind mount) also excludes `/opt/frigate/frigate/config/` — Frigate's own Python config package — leaving it at the old version while the rest of the rootfs is updated.

Hit in practice updating 0.17.1 → 0.17.2: the sync reported success, but Frigate crash-looped with

    ImportError: cannot import name 'ChaptersEnum' from 'frigate.config.camera.record'

because `frigate/config/**` was still 0.17.1. The same applies to the `media/frigate`, `dev/shm`, and `tmp/cache` excludes matching any same-named path inside the image.

Anchoring the patterns with a leading `/` limits them to the actual mount points at the rootfs top level. Verified on PVE (ZFS, unprivileged OCI CT): after this change the re-run synced `frigate/config/**` correctly and 0.17.2 starts normally.